### PR TITLE
Fixed bug to SnapshotInterval default value in ProgramSettings

### DIFF
--- a/Sample.Presentation.Console/Settings/ProgramSettings.cs
+++ b/Sample.Presentation.Console/Settings/ProgramSettings.cs
@@ -15,7 +15,7 @@ namespace Sample.Presentation.Console
         public int TaskCount { get; set; } = 1;
         public int CommandCount { get; set; } = 10;
         public int MaxSleep { get; set; } = 10;
-        public int SnapshotInterval { get; set; } = 100;
+        public int SnapshotInterval { get; set; } = 10;
         public bool SaveAllCommands { get; set; } = false;
 
         public static Tenant CurrentTenant { get; set; } = Tenants.Acme;


### PR DESCRIPTION
In Scenario B: How to Take a Snapshot of an Aggregate the explanation is that after 10 events a snapshot will be taken. The code does not reflective this statement. The default value for SnapshotInterval in the ProgramSettings is 100. Changed the value to 10.