### PR TITLE
Remove reflections for finding When methods

### DIFF
--- a/Sample.Domain/Aggregates/AccountAggregate.cs
+++ b/Sample.Domain/Aggregates/AccountAggregate.cs
@@ -4,32 +4,30 @@ using Timeline.Events;
 
 namespace Sample.Domain
 {
-    public class AccountAggregate : AggregateRoot
+    public class AccountAggregate : AggregateRoot<Account>
     {
-        public override AggregateState CreateState() => new Account();
-
         public void OpenAccount(Guid owner, string code)
         {
             var e = new AccountOpened(owner, code);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void DepositMoney(decimal amount, Guid transaction)
         {
             var e = new MoneyDeposited(amount, transaction);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void WithdrawMoney(decimal amount, Guid transaction)
         {
             var e = new MoneyWithdrawn(amount, transaction);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void CloseAccount(string reason)
         {
             var e = new AccountClosed(reason);
-            Apply(e);
+            Apply(e, State.When);
         }
     }
 }

--- a/Sample.Domain/Aggregates/PersonAggregate.cs
+++ b/Sample.Domain/Aggregates/PersonAggregate.cs
@@ -4,32 +4,30 @@ using Timeline.Events;
 
 namespace Sample.Domain
 {
-    public class PersonAggregate : AggregateRoot
+    public class PersonAggregate : AggregateRoot<Person>
     {
-        public override AggregateState CreateState() => new Person();
-
         public void BoxPerson()
         {
             var e = new PersonBoxed();
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void UnboxPerson(Person person)
         {
             var e = new PersonUnboxed(person);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void RegisterPerson(string firstName, string lastName, DateTimeOffset registered)
         {
             var e = new PersonRegistered(firstName, lastName, registered);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void RenamePerson(string firstName, string lastName)
         {
             var e = new PersonRenamed(firstName, lastName);
-            Apply(e);
+            Apply(e, State.When);
         }
     }
 }

--- a/Sample.Domain/Aggregates/TransferAggregate.cs
+++ b/Sample.Domain/Aggregates/TransferAggregate.cs
@@ -4,26 +4,24 @@ using Timeline.Events;
 
 namespace Sample.Domain
 {
-    public class TransferAggregate : AggregateRoot
+    public class TransferAggregate : AggregateRoot<Transfer>
     {
-        public override AggregateState CreateState() => new Transfer();
-
         public void StartTransfer(Guid fromAccount, Guid toAccount, decimal amount)
         {
             var e = new TransferStarted(fromAccount, toAccount, amount);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void UpdateTransfer(string activity)
         {
             var e = new TransferUpdated(activity);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void CompleteTransfer()
         {
             var e = new TransferCompleted();
-            Apply(e);
+            Apply(e, State.When);
         }
     }
 }

--- a/Sample.Domain/Aggregates/UserAggregate.cs
+++ b/Sample.Domain/Aggregates/UserAggregate.cs
@@ -2,23 +2,21 @@
 
 namespace Sample.Domain
 {
-    public class UserAggregate : AggregateRoot
+    public class UserAggregate : AggregateRoot<User>
     {
-        public override AggregateState CreateState() => new User();
-
         public void StartRegistration(string name, string password)
         {
             var e = new UserRegistrationStarted(name, password);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void CompleteRegistration(string status)
         {
             if (status == "Succeeded")
-                Apply(new UserRegistrationSucceeded());
+                Apply(new UserRegistrationSucceeded(), State.When);
             
             else if (status == "Failed")
-                Apply(new UserRegistrationFailed());
+                Apply(new UserRegistrationFailed(), State.When);
         }
     }
 }

--- a/Sample.Persistence/Logs/Stores/EventStore.cs
+++ b/Sample.Persistence/Logs/Stores/EventStore.cs
@@ -179,7 +179,7 @@ ORDER BY
                 .Deserialize();
         }
 
-        public void Save(AggregateRoot aggregate, IEnumerable<IEvent> events)
+        public void Save(IAggregateRoot aggregate, IEnumerable<IEvent> events)
         {
             var current = _identityService.GetCurrent();
             var tenant = current.Tenant.Identifier;

--- a/Sample.Presentation.Console/Tests/Integration/Test04.cs
+++ b/Sample.Presentation.Console/Tests/Integration/Test04.cs
@@ -10,7 +10,7 @@ using Timeline.Commands;
 namespace Sample.Presentation.Console
 {
     /// <summary>
-    /// Scenario 4: How to create a new user with a unique login name
+    /// Scenario D: How to create a new user with a unique login name
     /// </summary>
     public class Test04
     {

--- a/Timeline/Events/AggregateRoot.cs
+++ b/Timeline/Events/AggregateRoot.cs
@@ -11,7 +11,7 @@ namespace Timeline.Events
     /// aggregate root is the top-level container, which speaks for the whole and may delegates down to the rest. It is 
     /// important because it is the one that the rest of the world communicates with.
     /// </summary>
-    public abstract class AggregateRoot
+    public abstract class AggregateRoot : IAggregateRoot
     {
         /// <summary>
         /// Changes to the state of the aggregate that are not yet committed to a persistent event store.

--- a/Timeline/Events/AggregateRoot.cs
+++ b/Timeline/Events/AggregateRoot.cs
@@ -11,17 +11,40 @@ namespace Timeline.Events
     /// aggregate root is the top-level container, which speaks for the whole and may delegates down to the rest. It is 
     /// important because it is the one that the rest of the world communicates with.
     /// </summary>
-    public abstract class AggregateRoot : IAggregateRoot
+    public abstract class AggregateRoot<TState> : IAggregateRoot
+        where TState : AggregateState, new ()
     {
         /// <summary>
         /// Changes to the state of the aggregate that are not yet committed to a persistent event store.
         /// </summary>
         private readonly List<IEvent> _changes = new List<IEvent>();
 
+        public AggregateRoot()
+        {
+            State = new TState();
+        }
+
         /// <summary>
         /// Represents the state (i.e. data/packet) for the aggregate.
         /// </summary>
-        public AggregateState State { get; set; }
+        public TState State { get; set; }
+
+        AggregateState IAggregateRoot.State
+        {
+            get
+            {
+                return State;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                State = (TState)value;
+            }
+        }
 
         /// <summary>
         /// Uniquely identifies the aggregate.
@@ -32,11 +55,6 @@ namespace Timeline.Events
         /// Current version of the aggregate.
         /// </summary>
         public int AggregateVersion { get; set; }
-
-        /// <summary>
-        /// Every aggregate must override this method to create the object that holds its current state.
-        /// </summary>
-        public abstract AggregateState CreateState();
 
         /// <summary>
         /// Returns all uncommitted changes. 
@@ -106,12 +124,12 @@ namespace Timeline.Events
         /// <summary>
         /// Applies a change to the aggregate state AND appends the event to the history of uncommited changes.
         /// </summary>
-        protected void Apply(IEvent change)
+        protected void Apply<T>(T changeEvent, Action<T> applyAction) where T : IEvent
         {
             lock (_changes)
             {
-                ApplyEvent(change);
-                _changes.Add(change);
+                applyAction(changeEvent);
+                _changes.Add(changeEvent);
             }
         }
 
@@ -121,9 +139,6 @@ namespace Timeline.Events
         /// </summary>
         protected virtual void ApplyEvent(IEvent change)
         {
-            if (State == null)
-                State = CreateState();
-
             State.Apply(change);
         }
     }

--- a/Timeline/Events/EventRepository.cs
+++ b/Timeline/Events/EventRepository.cs
@@ -20,7 +20,7 @@ namespace Timeline.Events
         /// <summary>
         /// Gets an aggregate from the event store.
         /// </summary>
-        public T Get<T>(Guid aggregate) where T : AggregateRoot
+        public T Get<T>(Guid aggregate) where T : IAggregateRoot
         {
             return Rehydrate<T>(aggregate);
         }
@@ -28,7 +28,7 @@ namespace Timeline.Events
         /// <summary>
         /// Saves all uncommitted changes to the event store.
         /// </summary>
-        public IEvent[] Save<T>(T aggregate, int? version) where T : AggregateRoot
+        public IEvent[] Save<T>(T aggregate, int? version) where T : IAggregateRoot
         {
             if (version != null && (_store.Exists(aggregate.AggregateIdentifier, version.Value)))
                 throw new ConcurrencyException(aggregate.AggregateIdentifier);
@@ -47,7 +47,7 @@ namespace Timeline.Events
         /// <summary>
         /// Loads an aggregate instance from the full history of events for that aggreate.
         /// </summary>
-        private T Rehydrate<T>(Guid id) where T : AggregateRoot
+        private T Rehydrate<T>(Guid id) where T : IAggregateRoot
         {
             // Get all the events for the aggregate.
             var events = _store.Get(id, -1);
@@ -73,7 +73,7 @@ namespace Timeline.Events
         /// Therefore this function in this class throws a NotImplementedException; refer to SnapshotRepository for the
         /// implementation.
         /// </remarks>
-        public void Box<T>(T aggregate) where T : AggregateRoot
+        public void Box<T>(T aggregate) where T : IAggregateRoot
         {
             throw new NotImplementedException();
         }
@@ -87,7 +87,7 @@ namespace Timeline.Events
         /// Therefore this function in this class throws a NotImplementedException; refer to SnapshotRepository for the
         /// implementation.
         /// </remarks>
-        public T Unbox<T>(Guid aggregateId) where T : AggregateRoot
+        public T Unbox<T>(Guid aggregateId) where T : IAggregateRoot
         {
             throw new NotImplementedException();
         }

--- a/Timeline/Events/IAggregateRoot.cs
+++ b/Timeline/Events/IAggregateRoot.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Timeline.Events
+{
+    public interface IAggregateRoot
+    {
+        Guid AggregateIdentifier { get; set; }
+
+        int AggregateVersion { get; set; }
+
+        AggregateState State { get; set; }
+
+        IEvent[] FlushUncommittedChanges();
+
+        IEvent[] GetUncommittedChanges();
+
+        void Rehydrate(IEnumerable<IEvent> history);
+    }
+}

--- a/Timeline/Events/IEventRepository.cs
+++ b/Timeline/Events/IEventRepository.cs
@@ -10,7 +10,7 @@ namespace Timeline.Events
         /// <summary>
         /// Returns the aggregate identified by the specified id.
         /// </summary>
-        T Get<T>(Guid id) where T : AggregateRoot;
+        T Get<T>(Guid id) where T : IAggregateRoot;
 
         /// <summary>
         /// Saves an aggregate.
@@ -18,16 +18,16 @@ namespace Timeline.Events
         /// <returns>
         /// Returns the events that are now saved (and ready to be published).
         /// </returns>
-        IEvent[] Save<T>(T aggregate, int? version = null) where T : AggregateRoot;
+        IEvent[] Save<T>(T aggregate, int? version = null) where T : IAggregateRoot;
 
         /// <summary>
         /// Copies an aggregate to offline storage and removes it from online logs.
         /// </summary>
-        void Box<T>(T aggregate) where T : AggregateRoot;
+        void Box<T>(T aggregate) where T : IAggregateRoot;
 
         /// <summary>
         /// Retrieves an aggregate from offline storage and returns only its most recent state.
         /// </summary>
-        T Unbox<T>(Guid aggregate) where T : AggregateRoot;
+        T Unbox<T>(Guid aggregate) where T : IAggregateRoot;
     }
 }

--- a/Timeline/Events/IEventStore.cs
+++ b/Timeline/Events/IEventStore.cs
@@ -33,7 +33,7 @@ namespace Timeline.Events
         /// <summary>
         /// Save events.
         /// </summary>
-        void Save(AggregateRoot aggregate, IEnumerable<IEvent> events);
+        void Save(IAggregateRoot aggregate, IEnumerable<IEvent> events);
 
         /// <summary>
         /// Copies an aggregate to offline storage and removes it from online logs.

--- a/Timeline/Snapshots/ISnapshotStrategy.cs
+++ b/Timeline/Snapshots/ISnapshotStrategy.cs
@@ -10,6 +10,6 @@ namespace Timeline.Snapshots
         /// <summary>
         /// Returns true if a snapshot should be taken for the aggregate.
         /// </summary>
-        bool ShouldTakeSnapShot(AggregateRoot aggregate);
+        bool ShouldTakeSnapShot(IAggregateRoot aggregate);
     }
 }

--- a/Timeline/Snapshots/SnapshotStrategy.cs
+++ b/Timeline/Snapshots/SnapshotStrategy.cs
@@ -20,7 +20,7 @@ namespace Timeline.Snapshots
         /// <summary>
         /// Returns true if a snapshot should be taken for the aggregate.
         /// </summary>
-        public bool ShouldTakeSnapShot(AggregateRoot aggregate)
+        public bool ShouldTakeSnapShot(IAggregateRoot aggregate)
         {
             var i = aggregate.AggregateVersion;
             for (var j = 0; j < aggregate.GetUncommittedChanges().Length; j++)


### PR DESCRIPTION
This one at first was a bit tricky. The solution is to turn `AggregateRoot` into a generic that knows the `Type` of its state but at the same time be able to work with an `AggregateRoot` in a none generic manner. The solution to this challenge is to program to an interface allowing the aggregate root to return a type specific `State` (TState) and the base type `AggregateState` through the interface.

Once that was figured out `AggregateRoot` was turned into a generic. Changes where also made to the `Apply` method making it a generic as well allowing the `When` method of `TEvent` to be passed to the `Apply` method of `AggregateRoot`. Now that the `Aggregate` knows of the `State` it then knows of the specific `When` methods of that `State` to be used when calling the `Apply` method.

These changes eliminated the need to do reflections on the state to determine which `When` method to call. The reflections method is still present in those cases of reapplying events from the event store.

I believe there are some other benefits besides performance. There are some benefits by using constraints on the generics Methods and Class. Enforce the When method to receive a parameter of `IEvent` and only one parameter can be passed. Making sure the `State` object type (TState) has a parameterless constructor which allows creating an instance of the type. This eliminates the need for the abstract  method  `CreateState` and also allows the `State` object to be created when the Aggregate is created.

And obviously the other benefit is that `State` is not type specific. Allowing all that IntelliSense and other type benefits without have to convert from base type to specific type.